### PR TITLE
Completed _get_disks(), returns almost all info from 'df -h' and 'mount'

### DIFF
--- a/sysinfo.py
+++ b/sysinfo.py
@@ -81,9 +81,28 @@ def _get_users():
 def _get_disks():
     try:
         ddisks = {}
-        df = subprocess.check_output(['df', '-h']).decode('utf-8').strip('\n').split()
-        mounts = subprocess.check_output('mount').decode('utf-8').strip('\n').split()
-        return
+        df_keys=['filesystem','size','used','avail','use%','mount']
+        df = subprocess.check_output(['df', '-h']).decode('utf-8').split('\n')
+        mounts = subprocess.check_output('mount').decode('utf-8')[:-1].split('\n')
+        
+        # pull info from 'df -h'
+        for line in df:
+            if('/dev' in line[:4]):
+                line=line.split()
+                ddisks.update({line[0]:dict()})
+                for i in range(1,6):
+                    ddisks[line[0]][df_keys[i]]=line[i]
+
+        # pull info from mount using new df dict
+        for m in mounts:
+            for d in ddisks:
+                m_info = m.split()
+                if(m_info[0]==d):
+                    #print(m_info[4])
+                    ddisks[d]['type']=m_info[4]
+                    #print(m_info[5].split(',')[0][1:])
+                    ddisks[d]['permission']=m_info[5].split(',')[0][1:]
+        return ddisks
         # {
         # 'sda': {
         #         'sda1': {
@@ -103,7 +122,7 @@ def _get_disks():
         #         }
         # }
     except:
-        return
+        return NULL
 
 def _detect_distro():
     return
@@ -196,7 +215,10 @@ def full_print():
 
     print('CPU:\t{}'.format(' '.join(_get_cpuinfo())))
     print('Memory:\t{used}/{total} Swap: {swap_used}/{swap_total}'.format(**_get_meminfo()))
-
+    print('Disks:')
+    for disk in _get_disks():
+        disk_info='Mounted:{mount} Used%:{use%} Avail:{avail} Size:{size} Type:{type} Permission:{permission}'.format(**_get_disks()[disk])
+        print('\t{}:\n\t{}'.format(disk,disk_info))
 def short_print():
     print(' '.join(_get_date()))
     print('{0}@{1}'.format(_get_current_user(), _get_fqdn()[0]))
@@ -214,12 +236,12 @@ def get_json():
     jdb['users'] = _get_users()
     jdb['cpu'] = _get_cpuinfo()
     jdb['mem'] = _get_meminfo()
+    jdb['disks'] = _get_disks()
     return jdb
 
 if __name__ == '__main__':
-     #full_print()
-     #print('==============================')
-     #short_print()
-     #with open('host.json', 'w') as outfile:
-     #    json.dump(get_json(), outfile)
-     _get_disks()
+     full_print()
+     print('==============================')
+     short_print()
+     with open('host.json', 'w') as outfile:
+        json.dump(get_json(), outfile)


### PR DESCRIPTION
``` json
{
"/dev/sda1": {
  "use%": "12%", 
  "used": "12G", 
  "permission": "rw", 
  "mount": "/", 
  "avail": "89G", 
  "type": "ext4", 
  "size": "107G"
  }
}
```

This is the final format of the dict storing the disks. Right now it detects whether the first value  in each line returned in `df -h` begins with `/dev`, so that all drives returned like `/dev/sda1`, `/dev/sdb1`, or `/dev/md0` will be returned. 
