### PR TITLE
Several methods fixed and tested

### DIFF
--- a/sysinfo.py
+++ b/sysinfo.py
@@ -82,24 +82,29 @@ def _get_disks():
     try:
         ddisks = {}
         df_keys=['filesystem','size','used','avail','use%','mount']
-        df = subprocess.check_output(['df', '-h']).decode('utf-8').split('\n')
+        df = subprocess.check_output(['df', '-h']).decode('utf-8')[:-1].split('\n')
         mounts = subprocess.check_output('mount').decode('utf-8')[:-1].split('\n')
         
         # pull info from 'df -h'
         for line in df:
+            #print('Line from df is: {}'.format(line))
             if('/'==line[0]):
                 line=line.split()
                 ddisks.update({line[5]:dict()})
                 for i in range(0,5):
                     ddisks[line[5]][df_keys[i]]=line[i]
+                #print('ddisks is now: \n{}'.format(ddisks))
 
         # pull info from mount using new df dict
-        for m in mounts:
+        #print('\n')
+	for m in mounts:
+	    #print('Line from mount is: {}'.format(m))
             for d in ddisks:
                 m_info = m.split()
                 if(m_info[2]==d):
                     ddisks[d]['type']=m_info[4]
                     ddisks[d]['permission']=m_info[5].split(',')[0][1:]
+		    #print('ddisks is now: \n{}'.format(ddisks))
         return ddisks
     
     except:

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -100,7 +100,7 @@ def _get_disks():
                 if(m_info[2]==d):
                     ddisks[d]['type']=m_info[4]
                     ddisks[d]['permission']=m_info[5].split(',')[0][1:]
-        return ddisks;
+        return ddisks
     
     except:
         return
@@ -197,9 +197,10 @@ def full_print():
     print('CPU:\t{}'.format(' '.join(_get_cpuinfo())))
     print('Memory:\t{used}/{total} Swap: {swap_used}/{swap_total}'.format(**_get_meminfo()))
     print('Disks:')
-    for disk in _get_disks():
-        disk_info='Mounted:{mount} Used%:{use%} Avail:{avail} Size:{size} Type:{type} Permission:{permission}'.format(**_get_disks()[disk])
-        print('\t{}:\n\t{}'.format(disk,disk_info))
+    _disk_dict = _get_disks()
+    for disk in _disk_dict:
+        disk_info='Mount:{0} Used%:{use%} Avail:{avail} Size:{size} Type:{type} Permission:{permission}'.format(disk,**_disk_dict[disk])
+        print('\t{}:\n\t{}'.format(_disk_dict[disk]['filesystem'],disk_info))
 def short_print():
     print(' '.join(_get_date()))
     print('{0}@{1}'.format(_get_current_user(), _get_fqdn()[0]))

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -62,7 +62,7 @@ def _get_ip_route():
 
 def _get_users():
     if not os.path.isfile('/etc/passwd'):
-        return NULL
+        return
     else:
         users = {}
         try:
@@ -75,7 +75,7 @@ def _get_users():
                                           'home':line[5],
                                           'shell':line[6]}
         except:
-            return NULL
+            return
         return users
 
 def _get_disks():
@@ -87,50 +87,31 @@ def _get_disks():
         
         # pull info from 'df -h'
         for line in df:
-            if('/dev' in line[:4]):
+            if('/'==line[0]):
                 line=line.split()
-                ddisks.update({line[0]:dict()})
-                for i in range(1,6):
-                    ddisks[line[0]][df_keys[i]]=line[i]
+                ddisks.update({line[5]:dict()})
+                for i in range(0,5):
+                    ddisks[line[5]][df_keys[i]]=line[i]
 
         # pull info from mount using new df dict
         for m in mounts:
             for d in ddisks:
                 m_info = m.split()
-                if(m_info[0]==d):
-                    #print(m_info[4])
+                if(m_info[2]==d):
                     ddisks[d]['type']=m_info[4]
-                    #print(m_info[5].split(',')[0][1:])
                     ddisks[d]['permission']=m_info[5].split(',')[0][1:]
-        return ddisks
-        # {
-        # 'sda': {
-        #         'sda1': {
-        #                 'fs':'vfat',
-        #                 'mount':'/boot/efi'
-        #                 },
-        #         'sda2': {
-        #                 'fs':'ext4',
-        #                 'mount':'/'
-        #                 }
-        #         },
-        # 'sdb': {
-        #         'sdb1': {
-        #                 'fs':'ntfs',
-        #                 'mount':'/windows'
-        #                 }
-        #         }
-        # }
+        return ddisks;
+    
     except:
-        return NULL
+        return
 
 def _detect_distro():
     return
 
 def _get_processes():
-  pdict = {'_total':len([c for c in subprocess.check_output(['ps','aux']) if('\n'==c)])-1}
-  [pdict.update({u:len([c for c in subprocess.check_output(['ps','-u',u]) if('\n'==c)])-1}) for u in _get_users()]
-  return pdict
+    pdict = {'_total':len([c for c in subprocess.check_output(['ps','aux']) if('\n'==c)])-1}
+    [pdict.update({u:len([c for c in subprocess.check_output(['ps','-u',u]) if('\n'==c)])-1}) for u in _get_users()]
+    return pdict
 
 def _get_hosts():
     return
@@ -240,8 +221,8 @@ def get_json():
     return jdb
 
 if __name__ == '__main__':
-     full_print()
-     print('==============================')
-     short_print()
-     with open('host.json', 'w') as outfile:
+    full_print()
+    print('==============================')
+    short_print()
+    with open('host.json', 'w') as outfile:
         json.dump(get_json(), outfile)

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -87,24 +87,19 @@ def _get_disks():
         
         # pull info from 'df -h'
         for line in df:
-            #print('Line from df is: {}'.format(line))
             if('/'==line[0]):
                 line=line.split()
                 ddisks.update({line[5]:dict()})
                 for i in range(0,5):
                     ddisks[line[5]][df_keys[i]]=line[i]
-                #print('ddisks is now: \n{}'.format(ddisks))
 
         # pull info from mount using new df dict
-        #print('\n')
 	for m in mounts:
-	    #print('Line from mount is: {}'.format(m))
             for d in ddisks:
                 m_info = m.split()
                 if(m_info[2]==d):
                     ddisks[d]['type']=m_info[4]
                     ddisks[d]['permission']=m_info[5].split(',')[0][1:]
-		    #print('ddisks is now: \n{}'.format(ddisks))
         return ddisks
     
     except:

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -47,18 +47,21 @@ def _get_ip_route():
     route = subprocess.check_output(['ip', 'route']).decode('utf-8').strip('\n')
     route = route.split('\n')
     routes = {}
-    for line in route:
-        info = line.split()
-        name = info[0]
-        routes[name] = {}
-        for i in range(1,len(info)):
-            if info[i] == 'dev':
-                routes[name]['dev'] = info[i+1]
-            elif info[i] == 'via':
-                routes[name]['via'] = info[i+1]
-            elif info[i] == 'src':
-                routes[name]['src'] = info[i+1]
-    return routes
+    try:
+        for line in route:
+            info = line.split()
+            name = info[0]
+            routes[name] = {}
+            for i in range(1,len(info)):
+                if info[i] == 'dev':
+                    routes[name]['dev'] = info[i+1]
+                elif info[i] == 'via':
+                    routes[name]['via'] = info[i+1]
+                elif info[i] == 'src':
+                    routes[name]['src'] = info[i+1]
+        return routes
+    except:
+        return 
 
 def _get_users():
     if not os.path.isfile('/etc/passwd'):
@@ -181,12 +184,13 @@ def full_print():
 
     print('Routes:')
     iproute = _get_ip_route()
-    for route in iproute:
-        proute = '\t{}'.format(route)
-        for key in iproute[route]:
-            #proute = proute+' '+key+' '+iproute[route][key]
-            proute = '{0} {1} {2}'.format(proute, key, iproute[route][key])
-        print(proute)
+    if iproute:
+        for route in iproute:
+            proute = '\t{}'.format(route)
+            for key in iproute[route]:
+                #proute = proute+' '+key+' '+iproute[route][key]
+                proute = '{0} {1} {2}'.format(proute, key, iproute[route][key])
+            print(proute)
 
     print('Users:')
     users = _get_users()

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -112,7 +112,8 @@ def _detect_distro():
 
 def _get_processes():
     pdict = {'_total':len([c for c in subprocess.check_output(['ps','aux']) if('\n'==c)])-1}
-    [pdict.update({u:len([c for c in subprocess.check_output(['ps','-u',u]) if('\n'==c)])-1}) for u in _get_users()]
+    pdict.update({'users':{}})
+    [pdict.update({'users':{u:len([c for c in subprocess.check_output(['ps','-u',u]) if('\n'==c)])-1}}) for u in _get_users()]
     return pdict
 
 def _get_hosts():
@@ -200,11 +201,19 @@ def full_print():
     print('CPU:\t{}'.format(' '.join(_get_cpuinfo())))
     print('Memory:\t{used}/{total} Swap: {swap_used}/{swap_total}'.format(**_get_meminfo()))
 
+    print('Processes:')
+    processes=_get_processes()
+    if(processes):
+        for username in processes['users']:
+            print('\t{0}: {1}'.format(username,processes['users'][username]))
+        print('\t{0}: {1}'.format('Total',processes['_total']))
+
     print('Disks:')
     _disk_dict = _get_disks()
     for disk in _disk_dict:
         disk_info='\t\tMount:{0}, Type:{type}, Permission:{permission},\n\t\tSize:{size}, Avail:{avail}, Used%:{use%}'.format(disk,**_disk_dict[disk])
         print('\t{}:\n{}'.format(_disk_dict[disk]['filesystem'],disk_info))
+
 
 def short_print():
     print(' '.join(_get_date()))

--- a/sysinfo.py
+++ b/sysinfo.py
@@ -94,7 +94,7 @@ def _get_disks():
                     ddisks[line[5]][df_keys[i]]=line[i]
 
         # pull info from mount using new df dict
-	for m in mounts:
+        for m in mounts:
             for d in ddisks:
                 m_info = m.split()
                 if(m_info[2]==d):
@@ -199,8 +199,8 @@ def full_print():
     print('Disks:')
     _disk_dict = _get_disks()
     for disk in _disk_dict:
-        disk_info='Mount:{0} Used%:{use%} Avail:{avail} Size:{size} Type:{type} Permission:{permission}'.format(disk,**_disk_dict[disk])
-        print('\t{}:\n\t{}'.format(_disk_dict[disk]['filesystem'],disk_info))
+        disk_info='\t\tMount:{0}, Type:{type}, Permission:{permission},\n\t\tSize:{size}, Avail:{avail}, Used%:{use%}'.format(disk,**_disk_dict[disk])
+        print('\t{}:\n{}'.format(_disk_dict[disk]['filesystem'],disk_info))
 def short_print():
     print(' '.join(_get_date()))
     print('{0}@{1}'.format(_get_current_user(), _get_fqdn()[0]))


### PR DESCRIPTION
### The following was fixed in this pull request
- `_get_processes()` 
  - added output in `full_print()`
  - dict formatting

``` json
    {
        "_total":210,
        "users":
            {"tom":72,
            "john":27,
            "chase":42}
    }
```
- `_get_disks()`:
  - Closed Issue #8 
  - proxy-fs compatibility (OpenVZ)
  - fixed output in `full_print()`
  - dict formatting

``` json
    {
        "/home":
            {"filesystem":"/dev/sda1",
            "size":"107G",
            "used":"19G",
            "avail":"88G",
            "use%":"14%",
            "type":"ext4",
            "permission":"rw"},
        "/":
            {"filesystem":"/dev/simfs",
            "size":"15G",
            "used":"0G",
            "avail":"15G",
            "use%":"1%",
            "type":"simfs",
            "permission":"rw"}
    }
```
- `_get_ip_route()`:
  - added error handling to return if no lines returned from ip route
    - occurs where no network connections exist
    - ie. no wireless connections on a plane
  - fixed output in `full_print()`
